### PR TITLE
修正KickoutSessionControlFilter队列添加sessionId后刷新到缓存中

### DIFF
--- a/shiro-example-chapter18/src/main/java/com/github/zhangkaitao/shiro/chapter18/web/shiro/filter/KickoutSessionControlFilter.java
+++ b/shiro-example-chapter18/src/main/java/com/github/zhangkaitao/shiro/chapter18/web/shiro/filter/KickoutSessionControlFilter.java
@@ -76,6 +76,7 @@ public class KickoutSessionControlFilter extends AccessControlFilter {
         //如果队列里没有此sessionId，且用户没有被踢出；放入队列
         if(!deque.contains(sessionId) && session.getAttribute("kickout") == null) {
             deque.push(sessionId);
+            cache.put(username, deque);
         }
 
         //如果队列里的sessionId数超出最大会话数，开始踢人


### PR DESCRIPTION
开涛大神你好，在使用您的shiro框架时，通过自定义过滤器KickoutSessionControlFilter控制并发在线人数这一功能。我发现使用您的18章用例中的KickoutSessionControlFilter类，并未能实现控制。
现经过个人从代码上的观察调试，发现需要加上部分代码，在加上我自己写的代码后，才使得控制生效。希望您看到后，能审查一下，我所添加部分代码是否正确。。
如果没有问题，希望能并入更新至您的git项目之中，谢谢！！！

如有任何问题，可以通过邮箱339452689@qq.com联系到我，再次致谢！